### PR TITLE
Hide error message in UI when cart is not full

### DIFF
--- a/examples/Lecture23/app.js
+++ b/examples/Lecture23/app.js
@@ -30,6 +30,7 @@ function ShoppingListController(ShoppingList) {
 
   list.removeItem = function (itemIndex) {
     ShoppingList.removeItem(itemIndex);
+    list.errorMessage = "";
   };
 }
 


### PR DESCRIPTION
The error message is initially not seen till cart becomes full. Then, even if items are removed from the cart, the error message keeps getting displayed. Added a line of code to remove the error message once a remove is done since that would bring the cart down from its max configured capacity.